### PR TITLE
Remove nodejs-legacy package from Conflicts field

### DIFF
--- a/resources/control-template
+++ b/resources/control-template
@@ -4,9 +4,7 @@ Section: devel, java, javascript
 Priority: optional
 Architecture: ${GRAALVM_ARCHITECTURE}
 Depends: ca-certificates-java, java-common (>= 0.28)
-Recommends: libxt-dev, nodejs-doc
-Conflicts: nodejs-legacy
-Replaces: nodejs-legacy
+Recommends: libxt-dev
 Provides: ${GRAALVM_PACKAGE_PROVIDES}
 Maintainer: Lee Dongjin <dongjin@apache.org>
 Homepage: https://www.graalvm.org/
@@ -26,8 +24,6 @@ Description: ${GRAALVM_DESCRIPTION}
  Javascrtipt Tools
  .
  .- js: A high performance implementation of the JavaScript programming language, Built on the GraalVM.
- .- node: A nodejs implementation built on the GraalVM.
- .- npm: A package manager for nodejs.
  .
  GraalVM Tools
  .

--- a/resources/control-template
+++ b/resources/control-template
@@ -4,7 +4,7 @@ Section: devel, java, javascript
 Priority: optional
 Architecture: ${GRAALVM_ARCHITECTURE}
 Depends: ca-certificates-java, java-common (>= 0.28)
-Recommends: libxt-dev
+Recommends: libxt-dev, nodejs-doc
 Provides: ${GRAALVM_PACKAGE_PROVIDES}
 Maintainer: Lee Dongjin <dongjin@apache.org>
 Homepage: https://www.graalvm.org/


### PR DESCRIPTION
Since GraalVM 21.1, the Node.js support is packaged in a separate
GraalVM component and needs to be installed separately using the gu
tool.